### PR TITLE
회원 탈퇴 성공시 스티비 주소록에서 삭제(main)

### DIFF
--- a/src/app/(admin)/admin/users/_components/modal/DeleteUserModal.tsx
+++ b/src/app/(admin)/admin/users/_components/modal/DeleteUserModal.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import UserManageModalWrapper from './UserManageModalWrapper';
 import Button from '@/components/Button/Button';
 import { deleteUser } from '@/service/admin';
-import { clearSelectedUsers, deleteUsers } from '@/redux/slice/adminUserListSlice';
+import { clearSelectedUsers, deleteUsers, useAdminUserList } from '@/redux/slice/adminUserListSlice';
 import { useEffect } from 'react';
 import ProgressView, {
   ProgressDoneViewProps,
@@ -15,6 +15,7 @@ import ProgressView, {
 } from '@/components/ProgressView';
 import { DeleteUserResponse } from '@/interfaces/Dto/Admin/DeleteUserDto';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { stibeeDeleteAddressApiAction } from '@/util/actions/stibee';
 
 function DeleteUserModal() {
   const { modal } = useModal('admin:deleteUser');
@@ -36,6 +37,8 @@ export default DeleteUserModal;
 const DeleteUserModalContent = () => {
   const { modal, closeModal, dispatch } = useModal('admin:deleteUser');
 
+  const { users } = useAdminUserList();
+
   const onDone: NonNullable<ProgressViewProps['onDone']> = ({ completedTaskResult }) => {
     const targetUserIdsPayload = (completedTaskResult as AxiosResponse<DeleteUserResponse>[]).map((result) => {
       const config = result.config as AxiosRequestConfig;
@@ -43,10 +46,16 @@ const DeleteUserModalContent = () => {
       return Number(config.url!.replace('/api/admin/user/delete/', ''));
     });
 
+    const deleteEmailList = users.filter((user) => targetUserIdsPayload.includes(user.id)).map((user) => user.email);
+
     dispatch(deleteUsers(targetUserIdsPayload));
 
     setTimeout(() => {
       dispatch(clearSelectedUsers());
+
+      stibeeDeleteAddressApiAction({
+        deleteEmailList,
+      }).then((res) => console.log('stibee delete', { res }));
     }, 0);
   };
 

--- a/src/app/mypage/membership/with-drawal/_components/Redirect.tsx
+++ b/src/app/mypage/membership/with-drawal/_components/Redirect.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { redirect } from 'next/navigation';
+import { useEffect } from 'react';
+
+function Redirect() {
+  useEffect(() => {
+    redirect('/');
+  }, []);
+
+  return <div>홈으로 이동 중...</div>;
+}
+
+export default Redirect;

--- a/src/app/mypage/membership/with-drawal/page.tsx
+++ b/src/app/mypage/membership/with-drawal/page.tsx
@@ -4,6 +4,7 @@ import { HttpStatusCode } from 'axios';
 import StepForm from '@/components/Form/StepForm';
 import { CheckWillProcess, WithDrawalForm } from '@/components/Form/MembershipWithDrawalForm';
 import { getProfile } from '@/service/user';
+import Redirect from './_components/Redirect';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -27,6 +28,7 @@ async function MembershipPage() {
     >
       <CheckWillProcess />
       <WithDrawalForm user={profilePayload.data} />
+      <Redirect />
     </StepForm>
   );
 }

--- a/src/components/Form/LoginForm/AdminVerifyForm.tsx
+++ b/src/components/Form/LoginForm/AdminVerifyForm.tsx
@@ -79,7 +79,14 @@ function AdminVerifyForm({ email, continueURL }: AdminVerifyFormProps) {
         httpOnly: true,
       });
 
+      queryClient.removeQueries({
+        predicate(query) {
+          return !query.queryHash.includes('profile');
+        },
+      });
       queryClient.invalidateQueries(ReactQueryHashKeys.getProfile);
+
+      revalidateAction('*');
 
       setTimeout(() => {
         replace(decodeURIComponent(continueURL ?? ROUTE_PATH.ADMIN.DASH_BOARD));

--- a/src/components/Form/MembershipWithDrawalForm/WithDrawalForm.tsx
+++ b/src/components/Form/MembershipWithDrawalForm/WithDrawalForm.tsx
@@ -3,7 +3,6 @@
 import { useLayoutEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { isMobile } from 'react-device-detect';
-import { useRouter } from 'next/navigation';
 import { ToastContainer } from 'react-toastify';
 import { HttpStatusCode } from 'axios';
 import Button from '@/components/Button/Button';
@@ -13,7 +12,8 @@ import { deleteCookie } from '@/util/cookies';
 import { type UseStepFormContext } from '../StepForm';
 import { type ProfilePayload } from '@/interfaces/Dto/User';
 import { useQueryClient } from '@tanstack/react-query';
-import { unSubscribe } from '@/service/subscribe';
+import { stibeeDeleteAddressApiAction } from '@/util/actions/stibee';
+// import { unSubscribe } from '@/service/subscribe';
 
 interface WithDrawalFormProps {
   user: ProfilePayload;
@@ -26,7 +26,6 @@ interface WithDrawalReason {
 
 function WithDrawalForm({ user }: WithDrawalFormProps) {
   const queryClient = useQueryClient();
-  const { push } = useRouter();
 
   const {
     register,
@@ -45,14 +44,16 @@ function WithDrawalForm({ user }: WithDrawalFormProps) {
       const { data: payload } = await membershipWithDrawal();
 
       if (payload.status === HttpStatusCode.Ok) {
-        await deleteCookie('accessToken');
-
-        queryClient.removeQueries({ queryKey: ['auth'] });
-        queryClient.removeQueries({ queryKey: ['profile'] });
+        await stibeeDeleteAddressApiAction({ deleteEmailList: [user.email] });
 
         done();
 
-        push('/');
+        setTimeout(async () => {
+          await deleteCookie('accessToken');
+
+          queryClient.removeQueries({ queryKey: ['auth'] });
+          queryClient.removeQueries({ queryKey: ['profile'] });
+        }, 0);
 
         return;
       }

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -7,6 +7,7 @@ export const API_ROUTE_PATH = {
     VERIFY_EMAIL: '/api/email/verify',
   },
   SIGNUP: '/api/join',
+  WITH_DRAWAL: '/api/auth/user',
   USER: {
     PROFILE: `/api/auth/user/me`,
   },

--- a/src/interfaces/Dto/Stibee/DeleteStibeeAddressDto.ts
+++ b/src/interfaces/Dto/Stibee/DeleteStibeeAddressDto.ts
@@ -4,6 +4,10 @@ interface ResponseKeyValue {
 }
 
 export interface DeleteStibeeAddressRequest {
+  /**
+   * 삭제 요청 이메일 리스트
+   * **string[]**
+   */
   deleteEmailList: string[];
 }
 

--- a/src/interfaces/Dto/Stibee/DeleteStibeeAddressDto.ts
+++ b/src/interfaces/Dto/Stibee/DeleteStibeeAddressDto.ts
@@ -1,0 +1,39 @@
+interface ResponseKeyValue {
+  Key: 'success' | 'fail';
+  Value: string[];
+}
+
+export interface DeleteStibeeAddressRequest {
+  deleteEmailList: string[];
+}
+
+export interface DeleteStibeeAddressResponse {
+  /**
+   * 요청 성공 실패 여부
+   *
+   * `true` 성공
+   *
+   * `false` 실패
+   */
+  Ok: boolean;
+  /**
+   * Ok 가 false 인 경우 에러 내용
+   *
+   * `code` 에러 코드
+   *
+   * `message` 에러 메시지
+   */
+  Error: {
+    code: string;
+    message: string;
+  } | null;
+  /**
+   * 요청에 대한 결과(Key-Value타입의 배열)
+   *
+   * Key 값
+   *
+   * `success` 구독자 완전삭제 성공 리스트
+   * `fail` 구독자 완전삭제 실패 리스트
+   */
+  Value: Record<ResponseKeyValue['Key'], ResponseKeyValue['Value']>;
+}

--- a/src/interfaces/Dto/Stibee/PostStibeeAddressDto.ts
+++ b/src/interfaces/Dto/Stibee/PostStibeeAddressDto.ts
@@ -1,17 +1,4 @@
-interface KnownUserInfoKeyValue {
-  /**
-   * 이메일
-   */
-  email: string;
-  /**
-   * 이름
-   */
-  name?: string;
-  /**
-   * 광고성 정보 수신 동의 여부
-   */
-  $ad_agreed?: 'Y' | 'N';
-}
+import { KnownStibeeUserInfo } from './core';
 
 interface ResponseKeyValue {
   Key:
@@ -25,7 +12,7 @@ interface ResponseKeyValue {
     | 'failDuplicatedEmail'
     | 'failDuplicatedPhone'
     | 'failUnknown';
-  Value: KnownUserInfoKeyValue[];
+  Value: KnownStibeeUserInfo[];
 }
 
 export interface PostStibeeAddressRequest {
@@ -56,7 +43,7 @@ export interface PostStibeeAddressRequest {
    *
    * `$ad_agreed` (기본값: 'N') 광고성 정보 수신 여부
    */
-  subscribers: KnownUserInfoKeyValue[];
+  subscribers: KnownStibeeUserInfo[];
 }
 
 export interface PostStibeeAdressResponse {
@@ -71,9 +58,9 @@ export interface PostStibeeAdressResponse {
   /**
    * Ok 가 false 인 경우 에러 내용
    *
-   * `Code` 에러 코드
+   * `code` 에러 코드
    *
-   * `Message` 에러 메시지
+   * `message` 에러 메시지
    */
   Error: {
     code: string;

--- a/src/interfaces/Dto/Stibee/core.ts
+++ b/src/interfaces/Dto/Stibee/core.ts
@@ -1,0 +1,14 @@
+export interface KnownStibeeUserInfo {
+  /**
+   * 이메일
+   */
+  email: string;
+  /**
+   * 이름
+   */
+  name?: string;
+  /**
+   * 광고성 정보 수신 동의 여부
+   */
+  $ad_agreed?: 'Y' | 'N';
+}

--- a/src/mocks/handler/auth/index.ts
+++ b/src/mocks/handler/auth/index.ts
@@ -4,5 +4,6 @@ import { profile } from './profile';
 import { requestAccessToken } from './requestAccessToken';
 import { signup } from './signup';
 import { mockAuthVerifyApi } from './verify';
+import { withDrawl } from './withDrawal';
 
-export const authHandler = [login, logout, signup, profile, requestAccessToken, ...mockAuthVerifyApi];
+export const authHandler = [login, logout, signup, withDrawl, profile, requestAccessToken, ...mockAuthVerifyApi];

--- a/src/mocks/handler/auth/withDrawal.ts
+++ b/src/mocks/handler/auth/withDrawal.ts
@@ -1,0 +1,18 @@
+import { API_ROUTE_PATH } from '@/constants/routePath';
+import { MembershipWithDrawalResponse } from '@/interfaces/Dto/User';
+import { getURL } from '@/util/url';
+import { HttpStatusCode } from 'axios';
+import { DefaultBodyType, HttpResponse, PathParams, http } from 'msw';
+
+export const withDrawl = http.delete<PathParams, DefaultBodyType, MembershipWithDrawalResponse>(
+  getURL(API_ROUTE_PATH.WITH_DRAWAL),
+  async () => {
+    return HttpResponse.json(
+      {
+        status: HttpStatusCode.Ok,
+        msg: '탈퇴 성공',
+      },
+      { status: HttpStatusCode.Ok },
+    );
+  },
+);

--- a/src/mocks/handler/stibee/index.ts
+++ b/src/mocks/handler/stibee/index.ts
@@ -1,3 +1,4 @@
 import { stibeeAddressApi } from './stibeeAddress';
+import { stibeeDeleteAddressApi } from './stibeeDeleteAddress';
 
-export const mockStibeeApi = [stibeeAddressApi];
+export const mockStibeeApi = [stibeeAddressApi, stibeeDeleteAddressApi];

--- a/src/mocks/handler/stibee/stibeeDeleteAddress.ts
+++ b/src/mocks/handler/stibee/stibeeDeleteAddress.ts
@@ -1,0 +1,29 @@
+import {
+  DeleteStibeeAddressRequest,
+  DeleteStibeeAddressResponse,
+} from '@/interfaces/Dto/Stibee/DeleteStibeeAddressDto';
+import { HttpStatusCode } from 'axios';
+import { HttpResponse, http } from 'msw';
+
+export const stibeeDeleteAddressApi = http.delete<
+  { listId: string },
+  DeleteStibeeAddressRequest['deleteEmailList'],
+  DeleteStibeeAddressResponse
+>(`https://api.stibee.com/v1/lists/:listId/subscribers`, async ({ request }) => {
+  const accessToken = request.headers.get('AccessToken');
+  const targetEmailList = await request.json();
+
+  return HttpResponse.json(
+    {
+      Ok: true,
+      Error: null,
+      Value: {
+        success: [...targetEmailList],
+        fail: [],
+      },
+    },
+    {
+      status: HttpStatusCode.Ok,
+    },
+  );
+});

--- a/src/service/stibee.ts
+++ b/src/service/stibee.ts
@@ -1,3 +1,7 @@
+import {
+  DeleteStibeeAddressRequest,
+  DeleteStibeeAddressResponse,
+} from '@/interfaces/Dto/Stibee/DeleteStibeeAddressDto';
 import { PostStibeeAddressRequest, PostStibeeAdressResponse } from '@/interfaces/Dto/Stibee/PostStibeeAddressDto';
 import axios, { AxiosResponse } from 'axios';
 
@@ -30,6 +34,21 @@ export async function stibeeAddressApi({
       },
     },
   );
+
+  return res;
+}
+
+export async function stibeeDeleteAddressApi({ deleteEmailList }: DeleteStibeeAddressRequest) {
+  const res = await axios.delete<
+    any,
+    AxiosResponse<DeleteStibeeAddressResponse>,
+    DeleteStibeeAddressRequest['deleteEmailList']
+  >(`https://api.stibee.com/v1/lists/${process.env.NEXT_PUBLIC_STIBEE_ID}/subscribers`, {
+    data: [...deleteEmailList],
+    headers: {
+      AccessToken: process.env.NEXT_PUBLIC_STIBEE_KEY,
+    },
+  });
 
   return res;
 }

--- a/src/service/stibee.ts
+++ b/src/service/stibee.ts
@@ -6,9 +6,9 @@ import { PostStibeeAddressRequest, PostStibeeAdressResponse } from '@/interfaces
 import axios, { AxiosResponse } from 'axios';
 
 /**
- * stibee 주소록 API
+ * stibee 주소록 추가 API
  *
- * @link https://help.stibee.com/hc/ko/articles/4756551371535-%EC%A3%BC%EC%86%8C%EB%A1%9D-API-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0#1-api--
+ * @link https://help.stibee.com/hc/ko/articles/4756551371535-%EC%A3%BC%EC%86%8C%EB%A1%9D-API-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0#h_5c2983c86c
  */
 export async function stibeeAddressApi({
   eventOccuredBy = 'MANUAL',
@@ -38,6 +38,11 @@ export async function stibeeAddressApi({
   return res;
 }
 
+/**
+ * stibee 주소록 삭제 API
+ *
+ * @link https://help.stibee.com/hc/ko/articles/4756551371535-%EC%A3%BC%EC%86%8C%EB%A1%9D-API-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0#h_bb2bbf9138
+ */
 export async function stibeeDeleteAddressApi({ deleteEmailList }: DeleteStibeeAddressRequest) {
   const res = await axios.delete<
     any,

--- a/src/util/actions/stibee.ts
+++ b/src/util/actions/stibee.ts
@@ -1,7 +1,8 @@
 'use server';
 
+import { DeleteStibeeAddressRequest } from '@/interfaces/Dto/Stibee/DeleteStibeeAddressDto';
 import { PostStibeeAddressRequest, PostStibeeAdressResponse } from '@/interfaces/Dto/Stibee/PostStibeeAddressDto';
-import { stibeeAddressApi } from '@/service/stibee';
+import { stibeeAddressApi, stibeeDeleteAddressApi } from '@/service/stibee';
 import { AxiosError } from 'axios';
 
 export async function stibeeAddressApiAction({
@@ -19,6 +20,27 @@ export async function stibeeAddressApiAction({
       subscribers,
       groupIds,
     });
+
+    return res.data;
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      const { response } = error as AxiosError<PostStibeeAdressResponse>;
+
+      console.log('stibee error', { error: response?.data });
+
+      return response?.data;
+    }
+
+    console.log('stibee error', { error });
+    return error;
+  }
+}
+
+export async function stibeeDeleteAddressApiAction({ deleteEmailList }: DeleteStibeeAddressRequest) {
+  'use server';
+
+  try {
+    const res = await stibeeDeleteAddressApi({ deleteEmailList });
 
     return res.data;
   } catch (error) {


### PR DESCRIPTION
## Motivation
[#78](https://github.com/TripleA-Project/TripleA-FrontEnd/issues/78)

## Proposed Changes
- 유저가 회원 탈퇴 성공시, 관리자 유저 관리에서 유저 탈퇴시 성공할 경우 해당 유저의 이메일을 스티비 주소록에서 삭제
