### PR TITLE
기사 상세 심볼칩 에러, 카운트 렌더링 수정 (main)

### DIFF
--- a/src/components/NewsDetail/Chip/ActionSymbolChip.tsx
+++ b/src/components/NewsDetail/Chip/ActionSymbolChip.tsx
@@ -26,7 +26,7 @@ function ActionSymbolChip({ symbol }: ActionSymbolChipProps) {
     if (loginRequired) return false;
 
     return !!likedSymbols.symbols?.find(
-      (likedSymbol) => likedSymbol.symbol.toUpperCase() === symbol.name.toUpperCase(),
+      (likedSymbol) => likedSymbol.symbol.toUpperCase() === symbol?.name?.toUpperCase(),
     );
   }
 

--- a/src/components/NewsDetail/Detail.tsx
+++ b/src/components/NewsDetail/Detail.tsx
@@ -126,8 +126,8 @@ function Detail({ newsDetailPayload, requestSymbol, user }: DetailProps) {
           <TopScrollButton />
         </NewsDetailContentWrapper>
       </article>
-      {newsDetailPayload.user.membership === 'BASIC' ? (
-        <BenefitBar benefitCount={newsDetailPayload.user.leftBenefitCount ?? 0} />
+      {newsDetailPayload.user.membership === 'BASIC' && newsDetailPayload.user.leftBenefitCount !== null ? (
+        <BenefitBar benefitCount={newsDetailPayload.user.leftBenefitCount} />
       ) : null}
       <ToastContainer
         position="bottom-center"


### PR DESCRIPTION
## Motivation
[#80](https://github.com/TripleA-Project/TripleA-FrontEnd/issues/80)

## Proposed Changes
- 기사 상세 심볼칩 에러 수정(symbol 의 name 이 null 인 경우 에러)
- 무료체험 유저의 경우 기사 상세에서 0회로 카운트가 렌더링되는 현상 수정(membership이 basic, 카운트가 null 로 응답이 오는 것을 반영)
